### PR TITLE
Invalid format string and forgotten arguments

### DIFF
--- a/charset/ascii.go
+++ b/charset/ascii.go
@@ -21,7 +21,7 @@ type codePointError struct {
 }
 
 func (e *codePointError) Error() string {
-	return fmt.Sprintf("Parse error at index %n: Code point %n is undefined in %s", e.i, e.cp, e.charset)
+	return fmt.Sprintf("Parse error at index %d: Code point %d is undefined in %s", e.i, e.cp, e.charset)
 }
 
 func (strict translateFromASCII) Translate(data []byte, eof bool) (int, []byte, error) {

--- a/charset/charset_test.go
+++ b/charset/charset_test.go
@@ -177,7 +177,7 @@ func testTranslatingReader(t *testing.T, tr charset.Translator, inReader, outRea
 	}
 	err = checkTranslation(data, outbuf.Bytes())
 	if err != nil {
-		t.Fatalf("translator %T, readers %T, %T, %v\n", err)
+		t.Fatalf("translator %T, readers %T, %T, %v\n", tr, inr, outr, err)
 	}
 }
 


### PR DESCRIPTION
Recent golang compiler complains about `%n` and unsufficient number of arguments given to `Fatalf`